### PR TITLE
Zns on bump to 1.3

### DIFF
--- a/hw/block/nvme.h
+++ b/hw/block/nvme.h
@@ -154,6 +154,7 @@ typedef struct NvmeNamespace {
     int32_t         nr_open_zones;
     int32_t         nr_active_zones;
     bool            aen_pending;
+    bool            attached;
 } NvmeNamespace;
 
 static inline NvmeLBAF *nvme_ns_lbaf(NvmeNamespace *ns)

--- a/include/block/nvme.h
+++ b/include/block/nvme.h
@@ -851,6 +851,10 @@ enum NvmeIdCns {
     NVME_ID_CNS_CS_NS             = 0x05,
     NVME_ID_CNS_CS_CTRL           = 0x06,
     NVME_ID_CNS_CS_NS_ACTIVE_LIST = 0x07,
+    NVME_ID_CNS_NS_PRESENT_LIST   = 0x10,
+    NVME_ID_CNS_NS_PRESENT        = 0x11,
+    NVME_ID_CNS_CS_NS_PRESENT_LIST = 0x1a,
+    NVME_ID_CNS_CS_NS_PRESENT     = 0x1b,
     NVME_ID_CNS_IO_COMMAND_SET    = 0x1c,
 };
 


### PR DESCRIPTION
Couldn't decide if enum NvmeIdCns should add an extra space to all the defines or not.
Right now NVME_ID_CNS_CS_NS_PRESENT_LIST has an extra space
compared to the other defines.